### PR TITLE
Adjust nonnull usage and standards for gcc-6 and clang-4

### DIFF
--- a/src/async_fuse_fs.c
+++ b/src/async_fuse_fs.c
@@ -19,6 +19,7 @@
 #define _ISOC99_SOURCE
 #define _POSIX_C_SOURCE 199309L
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <unistd.h>
 

--- a/src/async_fuse_fs_helpers.c
+++ b/src/async_fuse_fs_helpers.c
@@ -19,6 +19,7 @@
 #define _ISOC99_SOURCE
 #define _POSIX_C_SOURCE 199309L
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <sys/stat.h>
 

--- a/src/http_helpers.c
+++ b/src/http_helpers.c
@@ -142,7 +142,11 @@ http_request_string_response(http_request_handle_t rh,
                              http_status_code_t code,
                              const char *body,
                              event_handler_t cb, void *cb_ud) {
-  const size_t body_len = body ? strlen(body) : 0;
+  size_t body_len = 0;
+#ifndef __GNUC__ // ensured by nonnull attribute already, would emit warning otherwise
+    if(body)
+#endif
+      body_len = strlen(body);
   http_request_simple_response(rh, code, body, body_len, "text/plain",
                                LINKED_LIST_INITIALIZER, cb, cb_ud);
 }

--- a/src/libdavfuse.c
+++ b/src/libdavfuse.c
@@ -20,6 +20,7 @@
  * Implements a WebDAV server using a set of FUSE callbacks
  */
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define _ISOC99_SOURCE
 #define _POSIX_C_SOURCE 200112L
 

--- a/src/util_fs.c
+++ b/src/util_fs.c
@@ -18,6 +18,7 @@
 
 #define _ISOC99_SOURCE
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <assert.h>
 #include <stdbool.h>

--- a/src/webdav_backend_async_fuse.c
+++ b/src/webdav_backend_async_fuse.c
@@ -18,6 +18,7 @@
 
 #define _ISOC99_SOURCE
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <libgen.h>
 

--- a/src/webdav_server.c
+++ b/src/webdav_server.c
@@ -20,6 +20,7 @@
   An async webdav server
 */
 #define _ISOC99_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <assert.h>
 #include <limits.h>

--- a/src/webdav_server_xml_tinyxml2.cpp
+++ b/src/webdav_server_xml_tinyxml2.cpp
@@ -293,8 +293,10 @@ unlinkNode(tinyxml2::XMLNode *elt) {
 NON_NULL_ARGS2(2, 3)
 static bool
 serializeDoc(const tinyxml2::XMLDocument & doc, char **out_data, size_t *out_size) {
+#ifndef __GNUC__ // ensured by nonnull attribute
   assert(out_data);
   assert(out_size);
+#endif
 
   /* Windows XP can't handle newlines in XML gracefully... */
   bool compact = true;


### PR DESCRIPTION
There are deprecation markers for _BSD_SOURCE in recent glibc headers, and also a warning about useless check of body which is tagged with nonnull pragma for gcc already.